### PR TITLE
fix(account): Fields Not Included in JSON Body are Reset to Empty or Null During Update

### DIFF
--- a/internal/account/domain/repository/account_repository.go
+++ b/internal/account/domain/repository/account_repository.go
@@ -84,9 +84,12 @@ func (repo *AccountRepository) Update(id uuid.UUID, payload *types.AccountUpdate
 		return nil, err
 	}
 
-	account.FullName = payload.FullName
-	account.Email = payload.Email
-
+	if payload.FullName != "" {
+		account.FullName = payload.FullName
+	}
+	if payload.Email != "" {
+		account.Email = payload.Email
+	}
 	return account.Update(repo.db)
 }
 


### PR DESCRIPTION
When updating an account, only the field present in the JSON request body will be updated in the database. Fields not included in the JSON body will not be changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced account update functionality to prevent overwriting existing `FullName` and `Email` with empty values.

- **Bug Fixes**
	- Improved robustness of the account update operation by validating input before applying changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->